### PR TITLE
fix: avoid flash of visible menu on first load with JS

### DIFF
--- a/html/themes/custom/whd23/components/whd-header/whd-header.css
+++ b/html/themes/custom/whd23/components/whd-header/whd-header.css
@@ -62,15 +62,12 @@
  */
 .whd-site-logo {
   --whd-logo-width: 250px;
-  --whd-logo-aspect-ratio: calc(499.992 / 156.74487);
+  --whd-logo-aspect-ratio: calc(500 / 162);
 
   display: block;
   width: var(--whd-logo-width);
   height: calc(var(--whd-logo-width) / var(--whd-logo-aspect-ratio));
   margin-inline-end: calc(2rem + 36px);
-  background-repeat: no-repeat;
-  background-position: 50% 50%;
-  background-size: contain;
 }
 
 @media screen and (min-width: 342px) {
@@ -81,7 +78,6 @@
 
 .whd-site-logo:focus-visible {
   outline: none;
-  background: var(--whd-header-ui-color);
 }
 
 .whd-site-logo svg {
@@ -89,8 +85,10 @@
 }
 
 .whd-site-logo:focus-visible svg {
-  outline: 4px solid var(--whd-header-ui-color);
+  outline: 6px solid var(--whd-header-ui-color);
+  outline-offset: -1px;
   fill: var(--whd-header-bg-color);
+  background: var(--whd-header-ui-color);
 }
 
 /**

--- a/html/themes/custom/whd23/components/whd-header/whd-header.css
+++ b/html/themes/custom/whd23/components/whd-header/whd-header.css
@@ -209,13 +209,16 @@
   right: 0;
   left: 0;
   padding: 2rem 1rem;
-  transition: 0.1666s ease-in-out;
-  transition-property: transform, visibility;
   transform: translateY(-100%);
   text-align: center;
   color: white;
   border-bottom: 4px solid var(--cd-black);
   background: var(--brand-primary);
+}
+
+.js .main-nav__contents.is--processed {
+  transition: 0.1666s ease-in-out;
+  transition-property: transform, visibility;
   will-change: transform;
 }
 

--- a/html/themes/custom/whd23/components/whd-header/whd-header.js
+++ b/html/themes/custom/whd23/components/whd-header/whd-header.js
@@ -33,6 +33,9 @@
         mainNavContents.setAttribute('aria-hidden', String(pressed));
       });
 
+      // Allow transitions now that nav is set up
+      mainNavContents.classList.add('is--processed');
+
       // Clicking a link should shut the nav.
       mainNavLinks.forEach((el) => {
         el.addEventListener('click', closeNav);


### PR DESCRIPTION
Avoids the brief flash of styled nav (FOSN?) when JS is present by applying CSS transitions while JS sets up the menu to add the toggle button.