### PR TITLE
fix: remove Survivor Stories pretitle from details page

### DIFF
--- a/html/themes/custom/whd23/components/whd-story-page/whd-story-page.css
+++ b/html/themes/custom/whd23/components/whd-story-page/whd-story-page.css
@@ -3,7 +3,7 @@
  */
 
 :root {
-  --whd-story-bg-cutoff: 620px;
+  --whd-story-bg-cutoff: 490px;
 }
 
 .page-node-type-story {
@@ -39,16 +39,6 @@
 /**
  * Page contents
  */
-.survivor-story__pretitle {
-  margin-block-start: 4rem;
-  margin-block-end: 0;
-  text-align: center;
-  color: var(--cd-white);
-  text-shadow: .5px .5px 0 #0006;
-  font-size: 3.6rem;
-  font-size: clamp(2.4rem, 10vw, 3.6rem);
-}
-
 .page-node-type-story #block-whd23-page-title h1 {
   margin-block: 0;
   color: var(--cd-white);
@@ -69,10 +59,21 @@
 }
 
 .page-node-type-story .whd-images {
+  position: relative;
   width: 100%;
   max-width: var(--whd-content-max);
   margin-inline: auto;
   margin-block: 7rem;
+}
+
+.page-node-type-story .whd-images::after {
+  position: absolute;
+  z-index: -1;
+  bottom: -4rem;
+  width: 100vw;
+  height: 6rem;
+  content: '';
+  background: var(--cd-white);
 }
 
 @media screen and (min-width: 820px) {

--- a/html/themes/custom/whd23/templates/page--story.html.twig
+++ b/html/themes/custom/whd23/templates/page--story.html.twig
@@ -64,7 +64,6 @@
 
   {% block main %}
     <main aria-label="{{ 'Page content'|t }}" id="main-content" class="survivor-story">
-      <p class="survivor-story__pretitle">{{ 'Survivor Stories'|t }}</p>
       {{ page.page_title }}
       {{ page.content }}
     </main>


### PR DESCRIPTION
Since the 'safe zone' had to grow larger with the removal of the label, I had another think and added an element below the galleries so that the blue never peeks though the two/three image galleries.