### PR TITLE
fix: allow GA to track video

### DIFF
--- a/html/themes/custom/whd23/components/whd-video/whd-video.js
+++ b/html/themes/custom/whd23/components/whd-video/whd-video.js
@@ -42,7 +42,7 @@
 
   // Accepts a DOM element and replaces it with a YouTube iframe.
   function prepVideo(video) {
-    video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube-nocookie.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1" frameborder="0" allow="autoplay; fullscreen"></iframe>';
+    video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube-nocookie.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1&enablejsapi=1&origin=' + encodeURIComponent(video.dataset.videoOrigin) + '" frameborder="0" allow="autoplay; fullscreen"></iframe>';
   }
 
   // Warm TCP connections by adding <link>s to the <head>.

--- a/html/themes/custom/whd23/components/whd-video/whd-video.js
+++ b/html/themes/custom/whd23/components/whd-video/whd-video.js
@@ -42,7 +42,7 @@
 
   // Accepts a DOM element and replaces it with a YouTube iframe.
   function prepVideo(video) {
-    video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube-nocookie.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1&enablejsapi=1&origin=' + encodeURIComponent(video.dataset.videoOrigin) + '" frameborder="0" allow="autoplay; fullscreen"></iframe>';
+    video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1&enablejsapi=1&origin=' + encodeURIComponent(video.dataset.videoOrigin) + '" frameborder="0" allow="autoplay; fullscreen"></iframe>';
   }
 
   // Warm TCP connections by adding <link>s to the <head>.

--- a/html/themes/custom/whd23/templates/paragraph--video.html.twig
+++ b/html/themes/custom/whd23/templates/paragraph--video.html.twig
@@ -53,7 +53,10 @@
       {{ content.field_title }}
       {{ content.field_text }}
 
-      <div class="video" data-video-slug="{{ video_slug }}" data-video-button-label="{{ 'Load video'|t }}">
+      <div class="video"
+        data-video-slug="{{ video_slug }}"
+        data-video-button-label="{{ 'Load video'|t }}"
+        data-video-origin="{{ url('<front>')|render|trim('/') }}">
         <a href="{{ video_url }}"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
Trying to assemble JS tracking for GTM/GA4.

- [GA4 docs](https://support.google.com/analytics/answer/9216061?hl=en) suggest that JS tracking be enabled
- [YT Iframe API](https://developers.google.com/youtube/player_parameters#enablejsapi) explains `enablejsapi` URL param
- Luckily, I read further down the YT API page where the `origin` param says "specify origin when you use `enablejsapi`"
- I removed the "no-cookie" domain and am using vanilla youtube domain, just in case that ends up conflicting. I didn't want to do a second debug/deploy.