### PR TITLE
Video preconnect/related

### DIFF
--- a/html/themes/custom/whd23/components/whd-video/whd-video.js
+++ b/html/themes/custom/whd23/components/whd-video/whd-video.js
@@ -42,7 +42,7 @@
 
   // Accepts a DOM container and replaces its contents with a YouTube iframe.
   function prepVideo(video) {
-    video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1&enablejsapi=1&origin=' + encodeURIComponent(video.dataset.videoOrigin) + '" frameborder="0" allow="autoplay; fullscreen" sandbox="allow-same-origin allow-scripts"></iframe>';
+    video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1&rel=0&enablejsapi=1&origin=' + encodeURIComponent(video.dataset.videoOrigin) + '" frameborder="0" allow="autoplay; fullscreen" sandbox="allow-same-origin allow-scripts"></iframe>';
   }
 
   // Warm TCP connections by adding <link>s to the <head>.

--- a/html/themes/custom/whd23/components/whd-video/whd-video.js
+++ b/html/themes/custom/whd23/components/whd-video/whd-video.js
@@ -33,7 +33,7 @@
         return;
       }
 
-      addPrefetch('preconnect', 'https://www.youtube-nocookie.com');
+      addPrefetch('preconnect', 'https://www.youtube.com');
       addPrefetch('preconnect', 'https://www.google.com');
       thisVideo.dataset.videoConnected = 'true';
     });

--- a/html/themes/custom/whd23/components/whd-video/whd-video.js
+++ b/html/themes/custom/whd23/components/whd-video/whd-video.js
@@ -40,7 +40,7 @@
 
   });
 
-  // Accepts a DOM element and replaces it with a YouTube iframe.
+  // Accepts a DOM container and replaces its contents with a YouTube iframe.
   function prepVideo(video) {
     video.innerHTML = '<iframe class="video__iframe" src="https://www.youtube.com/embed/' + video.dataset.videoSlug + '?autoplay=1&playsinline=1&enablejsapi=1&origin=' + encodeURIComponent(video.dataset.videoOrigin) + '" frameborder="0" allow="autoplay; fullscreen" sandbox="allow-same-origin allow-scripts"></iframe>';
   }


### PR DESCRIPTION
- Fixes the preconnect code to use youtube.com proper
- Adds the `rel=0` query param to prevent tons of random videos from displaying once video finishes. Instead, the related videos will be from the same channel.