### PR TITLE
chore: fiddle unnecessarily with composer versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "drupal/social_auth_hid": "^3.2",
         "drupal/stable": "^2.0",
         "drupal/stage_file_proxy": "^2.1",
-        "drupal/translatable_menu_link_uri": "2.x",
+        "drupal/translatable_menu_link_uri": "^2.0",
         "drupal/user_display_name": "^1.1",
         "drupal/user_expire": "^1.1",
         "drupal/username_enumeration_prevention": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6983da35df0ce749056893f3e0a787b2",
+    "content-hash": "6d29638eab108ffd27de171203636b17",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Refs: updates

Had an issue updating the repo locally due to composer cache permissions, and ended up adjusting composer config to use the tag not the branch for translatable_menu_link_uri module.

This shouldn't affect anything, and didn't solve my problem, but it is good for consistency so I thought I'd make this PR.