### PR TITLE
chore: try removing dev config from main image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,6 @@ LABEL info.humanitarianresponse.build.date=$BUILD_DATE \
 
 COPY --from=builder /srv/www/assets /srv/www/assets/
 COPY --from=builder /srv/www/config /srv/www/config/
-COPY --from=builder /srv/www/config_dev /srv/www/config_dev/
 COPY --from=builder /srv/www/html /srv/www/html/
 COPY --from=builder /srv/www/vendor /srv/www/vendor/
 COPY --from=builder /srv/www/composer.json /srv/www/composer.json


### PR DESCRIPTION
Refs: OPS-9475

If we're only using config_dev locally, omit the directory in the builds that get deployed.